### PR TITLE
Update getting version of the image

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -138,7 +138,7 @@ runs:
         ( github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch' || github.event.pull_request.merged == true )
           &&
         inputs.build_type != 'stable'
-      run: echo "VERSION=$(docker run --rm husarion/${{ env.IMAGE_NAME }}:${{ inputs.ros_distro }}-nightly bash -c "cat /version.txt")" >> $GITHUB_ENV
+      run: echo "VERSION=$(docker run --rm --entrypoint /bin/bash husarion/${{ env.IMAGE_NAME }}:${{ inputs.ros_distro }}-nightly -c "cat /version.txt")" >> $GITHUB_ENV
       shell: bash
 
     - name: "[main] [dev] Build and push"


### PR DESCRIPTION
Entrypoints can have hardware specific instructions (e.g. panther: https://github.com/husarion/panther-docker/blob/ros1/ros_entrypoint.sh), so it will be better to omit entrypoint when retrieving image version.